### PR TITLE
Changes for moodle 4.2

### DIFF
--- a/markspersection_form.php
+++ b/markspersection_form.php
@@ -23,9 +23,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport_form.php');
+use mod_quiz\local\reports\attempts_report_options_form;
 
 /**
  * Quiz marks per section report settings form.
@@ -34,6 +32,6 @@ require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport_form.php');
  * @author    Marie-Eve Lévesque <marie-eve.levesque.8@umontreal.ca>
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
-class quiz_markspersection_settings_form extends mod_quiz_attempts_report_form {
+class quiz_markspersection_settings_form extends attempts_report_options_form {
 
 }

--- a/markspersection_options.php
+++ b/markspersection_options.php
@@ -23,10 +23,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport_options.php');
-
 /**
  * Class to store the options for a quiz_markspersection_report.
  *

--- a/markspersection_table.php
+++ b/markspersection_table.php
@@ -24,9 +24,6 @@
  */
 
 
-defined('MOODLE_INTERNAL') || die();
-
-require_once($CFG->dirroot . '/mod/quiz/report/attemptsreport_table.php');
 use quiz_markspersection\quiz_attemptreport;
 
 /**

--- a/tests/report_test.php
+++ b/tests/report_test.php
@@ -28,7 +28,6 @@ namespace quiz_markspersection;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
-require_once($CFG->dirroot . '/mod/quiz/report/default.php');
 require_once($CFG->dirroot . '/mod/quiz/report/reportlib.php');
 require_once($CFG->dirroot . '/mod/quiz/report/markspersection/report.php');
 

--- a/tests/table_test.php
+++ b/tests/table_test.php
@@ -28,7 +28,6 @@ namespace quiz_markspersection;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
-require_once($CFG->dirroot . '/mod/quiz/report/default.php');
 require_once($CFG->dirroot . '/mod/quiz/report/reportlib.php');
 require_once($CFG->dirroot . '/mod/quiz/report/markspersection/report.php');
 

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2021110900;
+$plugin->version  = 2023101500;
 $plugin->requires = 2021051704;
 $plugin->component = 'quiz_markspersection';
 $plugin->maturity  = MATURITY_STABLE;
-$plugin->release   = '1.0.2 (Build 2021110900)';
+$plugin->release   = '1.0.3 (Build 2023101500)';


### PR DESCRIPTION
Unit tests in moodle 4.2 are throwing deprecation warnings. I fixed them according to the warnings, ran unit tests and did some quick manual testing.

Maybe it would be a good idea to provide a separate branch `MOODLE_402_STABLE` including the following changes, as they are specific for moodle 4.2 and above.